### PR TITLE
docs: mention assembly support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,4 +4,4 @@ version = 4
 
 [[package]]
 name = "rns"
-version = "0.1.0"
+version = "0.1.1"


### PR DESCRIPTION
RNS supports assembly external symbol references, which allows users to write *extremely* low-level Neovim configurations. The example implementation follows x86_64 ABI conventions to ensure compatibility with the existing C FFI layer but I'm sure it works on other arches with minimal changes.